### PR TITLE
remove warning for max-params

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'curly': [ 'error', 'multi-line' ],
     'import/newline-after-import': [ 'off' ],
     'indent': [ 'error', 2 ],
+    'max-params': ['off'],
     'quote-props': [ 'error', 'consistent-as-needed' ],
     'object-shorthand': [ 'error', 'consistent' ],
     'semi': [ 'error', 'never' ],


### PR DESCRIPTION
Resolves #2 
Turns off max params warning in index.js