### PR TITLE
[Issue-7] Add eslint rule for template-tag-spacing <Anusha>

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ module.exports = {
     // force no semicolons
     'semi': ['error', 'never'],
 
+    // force one or more spaces between template tag functions and their template literals
+    'template-tag-spacing': ['error', 'always'],
+
     // do not force a style for component names
     // e.g. ColorHeader.js or color-header.js
     'unicorn/filename-case': ['off'],


### PR DESCRIPTION
Issue: 
This PR is related to the issue - https://github.com/Tram-One/eslint-config-tram-one/issues/7

Summary of changes:
Added a new eslint rule for template-tag-spacing that would force default 1 or more spaces between template tag functions and their template literals

Reference: https://eslint.org/docs/rules/template-tag-spacing